### PR TITLE
Plugin update / uninstall

### DIFF
--- a/pluginhelper.js
+++ b/pluginhelper.js
@@ -792,7 +792,7 @@ function update() {
         }
         execSync("/bin/mv *.zip /tmp/plugins/" + package.name + ".zip");
         socket.emit('updatePlugin', {url: 'http://127.0.0.1:3000/plugin-serve/'
-            + package.name + ".zip", category: package.category, name: package.name})
+            + package.name + ".zip", category: package.volumio_info.plugin_type, name: package.name})
         socket.on('installPluginStatus', function (data) {
             console.log("Progress: " + data.progress + "\nStatus :" + data.message)
             if(data.message == "Plugin Successfully Installed"){


### PR DESCRIPTION
This PR addresses two things:

1. In pluginhelper, when you do `volumio plugin update`, the `category`value that is sent in the payload of `updatePlugin` websocket message is wrong. It references the non-existent `category` field in package.json, when it should be `volumio_info.plugin_type`,

2. In pluginmanager, when a plugin is updated, the Node modules used by the plugin (including the plugin itself) are not cleared from the Node cache. When the plugin is enabled after the update, old code is loaded from the cache. This PR clears the Node cache for the plugin after update. The cache is also cleared when a plugin is uninstalled, to handle situations where the user first uninstalls a plugin, then installs a newer version of it (instead of updating directly).