### PR TITLE
Fix undefined variable access error with albumart

### DIFF
--- a/app/plugins/system_controller/volumiodiscovery/index.js
+++ b/app/plugins/system_controller/volumiodiscovery/index.js
@@ -428,7 +428,7 @@ ControllerVolumioDiscovery.prototype.getThisDevice = function () {
   var self = this;
 
   self.logger.info('Discovery: Getting this device information');
-
+  var artURL = '';
   var thisDevice = {};
   var thisState = self.commandRouter.volumioGetState();
   var ipAddresses = self.commandRouter.executeOnPlugin('system_controller', 'network', 'getCachedPAddresses', '');
@@ -443,13 +443,18 @@ ControllerVolumioDiscovery.prototype.getThisDevice = function () {
   thisDevice.name = self.commandRouter.sharedVars.get('system.name');
   thisDevice.type = config.get('device_type', 'device');
   thisDevice.serviceName = config.get('service');
+  
+  if(thisState.albumart !== undefined && thisState.albumart !== null) {
+	artURL = thisState.albumart.indexOf('http://') >= 0 ? thisState.albumart : thisDevice.host + thisState.albumart;
+  }
+  
   thisDevice.state = {
     status: thisState.status,
     volume: thisState.volume,
     mute: thisState.mute,
     artist: thisState.artist,
     track: thisState.title,
-    albumart: thisState.albumart.indexOf('http://') >= 0 ? thisState.albumart : thisDevice.host + thisState.albumart
+    albumart: artUrl
   };
 
   return thisDevice;


### PR DESCRIPTION
Adds check for undefined and null value before accessing albumart string, aswell as splits the assignment and parsing operations.

This should fix this error, but i do not know how i would go and test this in action.
`
info: Discovery: Getting this device information
Dec 03 16:53:48 passatmediacenter volumio[791]: info: CoreCommandRouter::volumioGetState
Dec 03 16:53:48 passatmediacenter volumio[791]: info: CoreCommandRouter::executeOnPlugin: network , getCachedPAddresses
Dec 03 16:53:48 passatmediacenter volumio[791]: An internal error occurred while serving an albumart. Details: TypeError: Cannot read property 'indexOf' of undefined
Dec 03 16:53:48 passatmediacenter volumio[791]:     at ControllerVolumioDiscovery.getThisDevice (/volumio/app/plugins/system_controller/volumiodiscovery/index.js:452:34)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at CoreCommandRouter.executeOnPlugin (/volumio/app/index.js:1057:32)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at ControllerSystem.getSystemInfo (/volumio/app/plugins/system_controller/system/index.js:431:45)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at CoreCommandRouter.executeOnPlugin (/volumio/app/index.js:1057:32)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at RESTApiSystem.getSystemInfo (/volumio/app/plugins/user_interface/rest_api/system.js:38:41)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at Layer.handle [as handle_request] (/volumio/node_modules/express/lib/router/layer.js:95:5)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at next (/volumio/node_modules/express/lib/router/route.js:137:13)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at Route.dispatch (/volumio/node_modules/express/lib/router/route.js:112:3)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at Layer.handle [as handle_request] (/volumio/node_modules/express/lib/router/layer.js:95:5)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at /volumio/node_modules/express/lib/router/index.js:281:22
Dec 03 16:53:48 passatmediacenter volumio[791]:     at Function.process_params (/volumio/node_modules/express/lib/router/index.js:335:12)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at next (/volumio/node_modules/express/lib/router/index.js:275:10)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at jsonParser (/volumio/node_modules/body-parser/lib/types/json.js:110:7)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at Layer.handle [as handle_request] (/volumio/node_modules/express/lib/router/layer.js:95:5)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at trim_prefix (/volumio/node_modules/express/lib/router/index.js:317:13)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at /volumio/node_modules/express/lib/router/index.js:284:7
Dec 03 16:53:48 passatmediacenter volumio[791]:     at Function.process_params (/volumio/node_modules/express/lib/router/index.js:335:12)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at next (/volumio/node_modules/express/lib/router/index.js:275:10)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at jsonParser (/volumio/node_modules/body-parser/lib/types/json.js:110:7)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at Layer.handle [as handle_request] (/volumio/node_modules/express/lib/router/layer.js:95:5)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at trim_prefix (/volumio/node_modules/express/lib/router/index.js:317:13)
Dec 03 16:53:48 passatmediacenter volumio[791]:     at /volumio/node_modules/express/lib/router/index.js:284:7
`
And for how to produce the error
1. Attach USB dac to volumio
2. Select it as output device
3. Shutdown volumio
4. remove USB dac.
5. Boot volumio
6. Add new items to queue from qobuz(propably all other services aswell)
