### PR TITLE
Fix websocket create playlist functionality

### DIFF
--- a/app/playlistManager.js
+++ b/app/playlistManager.js
@@ -40,7 +40,7 @@ PlaylistManager.prototype.createPlaylist = function (name) {
     }
   });
 
-  return self.listPlaylist();
+  return defer.promise
 };
 
 PlaylistManager.prototype.deletePlaylist = function (name) {

--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -491,11 +491,15 @@ function InterfaceWebUI (context) {
 
     connWebSocket.on('createPlaylist', function (data) {
       var selfConnWebSocket = this;
-
+	  
       var returnedData = self.commandRouter.playListManager.createPlaylist(data.name);
       returnedData.then(function (data) {
-        selfConnWebSocket.emit('pushListPlaylist', data);
         selfConnWebSocket.emit('pushCreatePlaylist', data);
+        /* Check if creation was succesful and push new content, on failure data would be same */
+        if(data.success === true) {
+          self.commandRouter.playListManager.listPlaylist().then(data =>
+              selfConnWebSocket.emit('pushListPlaylist', data));
+        }
       });
     });
 


### PR DESCRIPTION
Now correctly pushes the "Success" of command to client

Also pushes new playlists to client instead of the old ones without new addition, if the creation was successful, when it failed there is no need to push the playlists to client, since there would be nothing new in there.
