### PR TITLE
dacs.json update for ChipDip DAC support

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -18,6 +18,7 @@
     {"id":"bassmantis","name":"BassMantis-uHAT","overlay":"rpi-dac","alsanum":"2","alsacard":"sndrpirpidac","mixer":"","modules":"","script":"bassmantis-init.sh","needsreboot":"yes"},
     {"id":"bassmantis-mic","name":"BassMantis-uHAT with I2S Mic","overlay":"googlevoicehat-soundcard","alsanum":"2","alsacard":"sndrpigooglevoi","mixer":"","modules":"","script":"bassmantis-init.sh","needsreboot":"yes"},
     {"id":"bassowl","name":"BassOwl-HAT","overlay":"bassowl","alsanum":"2","alsacard":"bassowl","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
+    {"id":"chipdip-master-dac","name":"ChipDip DAC","overlay":"chipdip-dac","alsanum":"2","alsacard":"ChipDipDAC","mixer":"","modules":"","script":"","eeprom_name":"DSP Machine","needsreboot":"yes"},
     {"id":"fe-pi-audio","name":"Fe-Pi Audio","overlay":"fe-pi-audio","alsanum":"2","alsacard":"Audio","mixer":"PCM","modules":"","script":"","needsreboot":"yes"},
     {"id":"generic-dac","name":"Generic I2S DAC","overlay":"hifiberry-dac","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"hifiberry-amp","name":"HiFiBerry Amp","overlay":"hifiberry-amp","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"Master","modules":"","script":"","needsreboot":"yes"},


### PR DESCRIPTION
dacs.json file is modified by adding a string for ChipDip DAC.
DAC's driver and overlay are already in the Kernel.