### PR TITLE
Added alsacard attribute to Pisound, so it gets listed in the I²S list

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -53,7 +53,7 @@
     {"id":"phat-beat","name":"pHAT BEAT","overlay":"hifiberry-dac","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"phat-dac","name":"pHAT DAC","overlay":"hifiberry-dac","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"picade-hat","name":"Picade HAT","overlay":"hifiberry-dac","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"","modules":"","script":"","needsreboot":"yes","eeprom_name":["Picade HAT"]},
-    {"id":"pisound","name":"pisound","overlay":"pisound","alsanum":"2","mixer":"","modules":"","script":"","needsreboot":"no"},
+    {"id":"pisound","name":"Pisound","overlay":"pisound","alsanum":"2","alsacard":"pisound","mixer":"","modules":"","script":"","needsreboot":"no","eeprom_name":["Pisound"]},
     {"id":"raspiaudio","name":"raspiaudio","overlay":"googlevoicehat-soundcard","alsanum":"2","alsacard":"sndrpigooglevoi","mixer":"","modules":"","script":"","needsreboot":"yes"} ,
     {"id":"rpi-dac","name":"R-PI DAC","overlay":"rpi-dac","alsanum":"2","alsacard":"sndrpirpidac","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"soekris-dac","name":"Soekris dam 1021","overlay":"hifiberry-dac","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"","modules":"","script":"","needsreboot":"yes"},


### PR DESCRIPTION
By the way, if possible, picking Pisound should default to enable software volume control, as hardware volume control is not available.