### PR TITLE
Sync status pause when paused from plugin service

### DIFF
--- a/app/statemachine.js
+++ b/app/statemachine.js
@@ -908,6 +908,7 @@ CoreStateMachine.prototype.syncState = function (stateService, sService) {
          */
 
     if (this.currentStatus === 'play') {
+      this.currentStatus = 'pause';
       if (this.isConsume) {
         this.consumeState.status = 'pause';
         this.pushState().fail(this.pushError.bind(this));


### PR DESCRIPTION
When a consuming music service pushes a status pause (from an external control), it is not written to stateMachine.currentStatus, which in turn leads to that switching to play from within volumio does not work