### PR TITLE
fix: crucial typos which produced unexpected results

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -873,7 +873,7 @@ CoreCommandRouter.prototype.restorePlaylistBackup = function () {
   var isbackup = check[0];
 
   if (isbackup) {
-    self.restorePlaylist({'type': 'playlist', 'backup': backup});
+    self.restorePlaylist({'type': 'playlist', 'backup': check[1]});
   }
 };
 

--- a/app/playqueue.js
+++ b/app/playqueue.js
@@ -2,7 +2,7 @@
 
 var libQ = require('kew');
 var fs = require('fs-extra');
-var execSync = require('child_process').execSync;
+var exec = require('child_process').exec;
 const NodeCache = require( "node-cache" );
 
 // Define the CorePlayQueue class
@@ -308,7 +308,7 @@ CorePlayQueue.prototype.moveQueueItem = function (from, to) {
   if (this.arrayQueue.length > to) {
     this.arrayQueue.splice(to, 0, this.arrayQueue.splice(from, 1)[0]);
     return this.commandRouter.volumioPushQueue(this.arrayQueue);
-  } else return defer.resolve();
+  } else return libQ.resolve();
 };
 
 CorePlayQueue.prototype.saveQueue = function () {

--- a/app/plugins/music_service/mpd/index.js
+++ b/app/plugins/music_service/mpd/index.js
@@ -681,7 +681,7 @@ ControllerMpd.prototype.mpdEstablish = function () {
   // Catch and log errors
   self.clientMpd.on('error', function (err) {
     self.logger.error('MPD error: ' + err);
-    if (err = "{ [Error: This socket has been ended by the other party] code: 'EPIPE' }") {
+    if (err === "{ [Error: This socket has been ended by the other party] code: 'EPIPE' }") {
       // Wait 5 seconds before trying to reconnect
       setTimeout(function () {
         self.mpdEstablish();
@@ -1859,18 +1859,6 @@ ControllerMpd.prototype.updateDb = function (data) {
   return self.sendMpdCommand('update', [pos]);
 };
 
-ControllerMpd.prototype.getGroupVolume = function () {
-  var self = this;
-  return self.sendMpdCommand('status', [])
-    .then(function (objState) {
-      var state = self.parseState(objState);
-      if (state.volume != undefined) {
-        state.volume = groupvolume;
-        return libQ.resolve(groupvolume);
-      }
-    });
-};
-
 ControllerMpd.prototype.setGroupVolume = function (data) {
   var self = this;
   return self.sendMpdCommand('setvol', [data]);
@@ -2842,7 +2830,7 @@ ControllerMpd.prototype.getGroupVolume = function () {
   var self = this;
   var defer = libQ.defer();
 
-  return self.sendMpdCommand('status', [])
+  self.sendMpdCommand('status', [])
     .then(function (objState) {
       if (objState.volume) {
         defer.resolve(objState.volume);
@@ -2918,7 +2906,7 @@ ControllerMpd.prototype.handleBrowseUri = function (curUri, previous) {
         response = self.listArtist(curUri, 3, 'genres://' + splitted[2], 'genres://');
       } else if (splitted.length == 5) {
         response = self.listAlbumSongs(curUri, 4, 'genres://' + splitted[2]);
-      } else if (splitted.length = 6) {
+      } else if (splitted.length == 6) {
         response = self.listAlbumSongs(curUri, 4, 'genres://' + splitted[4] + '/' + splitted[5]);
       }
     }


### PR DESCRIPTION
In this MR fixes only crucial linting errors which lead to unexpected behavior - e.g. `=` instead of `==`. 

Inspected only a few files, which I touched. 

Full commit with fixing other mistakes, like unused variables, redundant conditions, you can find in my fork - https://github.com/phts/NP-01_volumio3-backend/commit/e842fac4467ef36c5b926e515e6a1e32f1aa43cc

Please set up latest eslint with recommended config at least to catch such mistakes.
