### PR TITLE
Update dacs.json

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -84,6 +84,6 @@
     {"id":"iqaudio-dacplus","name":"IQaudIO DAC Plus","overlay":"iqaudio-dacplus","alsanum":"0","mixer":"Digital","modules":"","script":"iqamp-unmute.sh","needsreboot":"yes"},
     {"id":"rpi-dac","name":"R-PI DAC","overlay":"rpi-dac","alsanum":"0","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"wisdPi Hifi DAC","name":"wisdPi Hifi DAC","overlay":"hifiberry-dacplus","alsanum":"0","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
-    {"id":"52Pi NVDAC","name":"52Pi NVDAC","overlay":"hifiberry-dacplus,slave","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"Digital","modules":"","script":"","needsreboot":"yes"} 
+    {"id":"52Pi NVDAC","name":"52Pi NVDAC","overlay":"hifiberry-dacplus","alsanum":"0","mixer":"Digital","modules":"","script":"","needsreboot":"yes"} 
   ]}
 ]}

--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -83,6 +83,7 @@
     {"id":"hifiberry-dacplus","name":"HiFiBerry DAC Plus","overlay":"hifiberry-dacplus","alsanum":"0","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"iqaudio-dacplus","name":"IQaudIO DAC Plus","overlay":"iqaudio-dacplus","alsanum":"0","mixer":"Digital","modules":"","script":"iqamp-unmute.sh","needsreboot":"yes"},
     {"id":"rpi-dac","name":"R-PI DAC","overlay":"rpi-dac","alsanum":"0","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
-    {"id":"wisdPi Hifi DAC","name":"wisdPi Hifi DAC","overlay":"hifiberry-dacplus","alsanum":"0","mixer":"Digital","modules":"","script":"","needsreboot":"yes"}
+    {"id":"wisdPi Hifi DAC","name":"wisdPi Hifi DAC","overlay":"hifiberry-dacplus","alsanum":"0","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
+    {"id":"52Pi NVDAC","name":"52Pi NVDAC","overlay":"hifiberry-dacplus,slave","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"Digital","modules":"","script":"","needsreboot":"yes"} 
   ]}
 ]}

--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -67,7 +67,8 @@
     {"id":"st400-dac-amp","name":"ST400 Dac (PCM5122) - Amp","overlay":"iqaudio-dacplus","alsanum":"2","alsacard":"IQaudIODAC","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
     {"id":"taudac","name":"TauDAC - DM101","overlay":"taudac","alsanum":"2","alsacard":"TauDACDM101","mixer":"","modules":"","script":"","eeprom_name":"TauDAC-DM101","needsreboot":"yes"},
     {"id":"terraberry-dac2","name":"Terra-Berry DAC 2/3","overlay":"i-sabre-q2m","alsanum":"2","alsacard":"DAC","mixer":"","modules":"","script":"","needsreboot":"yes"},
-    {"id":"wisdPi Hifi DAC","name":"wisdPi Hifi DAC","overlay":"hifiberry-dacplus,slave","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"Digital","modules":"","script":"","needsreboot":"yes"}
+    {"id":"wisdPi Hifi DAC","name":"wisdPi Hifi DAC","overlay":"hifiberry-dacplus,slave","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
+    {"id":"52Pi NVDAC","name":"52Pi NVDAC","overlay":"hifiberry-dacplus,slave","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"Digital","modules":"","script":"","needsreboot":"yes"} 
   ]},
   {"name":"Odroid C1+","data":[
     {"id":"odroid-hifi-shield","name":"HiFi Shield","overlay":"","alsanum":"2","mixer":"","modules":"","script":""}


### PR DESCRIPTION
add 52Pi NVDAC board to dacs.json file.
The 52Pi NVDAC  is a HiFiBerry DAC+ Standard and PCIe to NVMe SSD 2242/2230 slot supported hat board which is from 52Pi. 
