### PR TITLE
Encapsulating raspberry  PI install to disk logic

### DIFF
--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -163,7 +163,7 @@ ControllerSystem.prototype.getUIConfig = function () {
                   uiconf.sections[4].hidden = true;
                 }
               }
-            } else (disklist.length > 0 ) {
+            } else if (disklist.length > 0 ) {
               uiconf.sections[4].hidden = false;
             }
               for (var i in disklist) {

--- a/app/plugins/system_controller/system/index.js
+++ b/app/plugins/system_controller/system/index.js
@@ -146,23 +146,24 @@ ControllerSystem.prototype.getUIConfig = function () {
           disks.then(function (result) {
             if (result.available.length > 0) {
               var disklist = result.available;
-              var blacklisted = ('1sda', '1sdb', '1sdc', '1sdd');
-              // Check if the device has boot from USB capability
-              if (usbbootdevice === '') {
-                uiconf.sections[4].hidden = true;
-              } else if (usbbootdevice === 'bootusb') {
-                // Prevent listing devices other than NVMe as a target.
-                // var disksToRemove = disklist.filter(x => x.name === 'eMMC/SD');
-                var disksToRemove = disklist.filter(x => x.name !== 'NVMe');
-                disksToRemove.forEach(x => disklist.splice(disklist.findIndex(n => n === x), 1));
-                console.log('Disk list : ', disklist);
-                if (disklist.length > 0 ) {
-                uiconf.sections[4].hidden = false;
-              } else {
-                // Installer should not be offered for cloning
-                uiconf.sections[4].hidden = true;
+              if (hwdevice === 'Raspberry PI') {
+                var blacklisted = ('sda', 'sdb', 'sdc', 'sdd');
+                // Check if the device has boot from USB capability
+                if (usbbootdevice === '') {
+                  uiconf.sections[4].hidden = true;
+                } else if (usbbootdevice === 'bootusb') {
+                  // Prevent listing devices other than NVMe as a target.
+                  var disksToRemove = disklist.filter(x => x.name !== 'NVMe');
+                  disksToRemove.forEach(x => disklist.splice(disklist.findIndex(n => n === x), 1));
+                  console.log('Disk list : ', disklist);
+                  if (disklist.length > 0 ) {
+                  uiconf.sections[4].hidden = false;
+                } else {
+                  // Installer should not be offered for cloning
+                  uiconf.sections[4].hidden = true;
+                }
               }
-            } else {
+            } else (disklist.length > 0 ) {
               uiconf.sections[4].hidden = false;
             }
               for (var i in disklist) {


### PR DESCRIPTION
Since usbbootdevice test is always false on x86 the first uiconf.sections[4].hidden = true; takes the precedence. Encapsulating Raspberry PI