### PR TITLE
Adding support for Interlude Audio HAT's

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -33,6 +33,8 @@
     {"id":"hifiberry-dacplusdsp","name":"HiFiBerry DAC Plus DSP","overlay":"hifiberry-dacplusdsp","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"Digital","modules":"","script":"","i2c_address":"4d","needsreboot":"no"},
     {"id":"hifiberry-dac2hd","name":"HiFiBerry DAC2 HD","overlay":"hifiberry-dacplushd","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"DAC","modules":"","script":"","eeprom_name":"DAC 2 HD","i2c_adress":"4d","needsreboot":"no"},
     {"id":"hifiberry-digi","name":"HiFiBerry Digi","overlay":"hifiberry-digi","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"","modules":"","script":"","needsreboot":"yes"},
+    {"id":"interludeaudio-digital","name":"Interlude Audio Digital Hat","overlay":"interludeaudio-digital","alsanum":"2","alsacard":"snd_IA_Anlog_Hat","mixer":"","modules":"","script":"","needsreboot":"yes"},
+    {"id":"interludeaudio-analog","name":"Interlude Audio Analog Hat","overlay":"interludeaudio-analog","alsanum":"2","alsacard":"snd_IA_Digital_Hat","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"hifiberry-digi-pro","name":"HiFiBerry Digi+ Pro","overlay":"hifiberry-digi-pro","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"","modules":"","script":"","needsreboot":"no"},
     {"id":"hifibox-dac","name":"HiFiBox DAC","overlay":"hifiberry-dacplus","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"Digital","modules":"","script":"","eeprom_name":["HiFiBox DAC HAT","HiFiBox DAC HAT V1","HiFiBox DAC HAT V 10"],"needsreboot":"no"},
     {"id":"melopero-daczero","name":"Melopero DAC ZERO","overlay":"hifiberry-dacplus","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"Digital","modules":"","script":"","i2c_address":"4d","needsreboot":"yes"},


### PR DESCRIPTION
We would like to add support for Interlude Audio Digital and Analog HAT's to Volumio. Our driver changes have already been merged with the official Raspberry Pi linux Kernel and are now available as part of the latest Raspbian Distribution. 