### PR TITLE
 Reverting mpd service re-cycle.

### DIFF
--- a/app/plugins/music_service/mpd/index.js
+++ b/app/plugins/music_service/mpd/index.js
@@ -833,7 +833,7 @@ ControllerMpd.prototype.savePlaybackOptions = function (data) {
     self.config.set('iso', data['iso']);
     if (isonew) {
       // iso enabled
-      execSync('/usr/bin/sudo /bin/systemctl stop mpd.service; /usr/bin/sudo /bin/systemctl stop mpd.socket ', {uid: 1000, gid: 1000, encoding: 'utf8'});
+      execSync('/usr/bin/sudo /bin/systemctl stop mpd.service', {uid: 1000, gid: 1000, encoding: 'utf8'});
       execSync('echo "volumio" | sudo -S /bin/cp -f /usr/bin/mpdsacd /usr/bin/mpd', {
         uid: 1000,
         gid: 1000,
@@ -935,13 +935,13 @@ ControllerMpd.prototype.restartMpd = function (callback) {
   var self = this;
 
   if (callback) {
-    exec('/usr/bin/sudo /bin/systemctl stop mpd.service; /usr/bin/sudo /bin/systemctl stop mpd.socket; sleep 2; /usr/bin/sudo /bin/systemctl start mpd.service ', {uid: 1000, gid: 1000},
+    exec('/usr/bin/sudo /bin/systemctl restart mpd.service ', {uid: 1000, gid: 1000},
       function (error, stdout, stderr) {
         self.mpdEstablish();
         callback(error);
       });
   } else {
-    exec('/usr/bin/sudo /bin/systemctl stop mpd.service; /usr/bin/sudo /bin/systemctl stop mpd.socket; sleep 2; /usr/bin/sudo /bin/systemctl start mpd.service ', {uid: 1000, gid: 1000},
+    exec('/usr/bin/sudo /bin/systemctl restart mpd.service ', {uid: 1000, gid: 1000},
       function (error, stdout, stderr) {
         if (error) {
           self.logger.error('Cannot restart MPD: ' + error);


### PR DESCRIPTION
Plugins like mpd_oled uses single mpd.service unit to manage state. It is very likely that there are other plugins alike.
Moving socket recycle to the systemd unit recycle. 