### PR TITLE
allow shairport to control volume

### DIFF
--- a/app/plugins/music_service/airplay_emulation/shairport-sync.conf.tmpl
+++ b/app/plugins/music_service/airplay_emulation/shairport-sync.conf.tmpl
@@ -1,6 +1,7 @@
 general =
 {
     name = "${name}";
+    ignore_volume_control = "yes"
 };
 
 diagnostics =


### PR DESCRIPTION
Fixes a problem when AirPlay playback volume is limited by the system volume as reported on the community forums [here](https://community.volumio.com/t/airplay-volume-limited-to-volumio-ui-volume-setting/7630) and [here](https://community.volumio.com/t/airplay-hardware-volume-control/12636).

Currently there are two separate volume controls: one managed by shairport-sync, responding to the source volume changes; second managed by Volumio, responding to the changes in UI and other events.

The PR changes the behavior by setting `ignore_volume_control` in the shairport-sync.conf file, effectively disabling the volume control done by shairport-sync itself, and passing the volume change events from the source to Volumio, letting it do the volume control as it should.


PS: This is my first contribution to Volumio, discussion is welcome :)