### PR TITLE
Add support for Raspberry Pi DAC+

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -86,6 +86,7 @@
     {"id":"picade-hat","name":"Picade HAT","overlay":"hifiberry-dac","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"","modules":"","script":"","needsreboot":"yes","eeprom_name":["Picade HAT"]},
     {"id":"pisound","name":"Pisound","overlay":"pisound","alsanum":"2","alsacard":"pisound","mixer":"","modules":"","script":"","needsreboot":"yes","eeprom_name":["Pisound"]},
     {"id":"i2s-dac","name":"R-PI DAC","overlay":"i2s-dac","alsanum":"2","alsacard":"sndrpirpidac","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},
+    {"id":"rpi-dacplus","name":"Raspberry Pi DAC+","overlay":"rpi-dacplus","alsanum":"2","alsacard":"DAC","mixer":"Digital","modules":"","script":"","eeprom_name":["Raspberry Pi DAC Plus"],"needsreboot":"yes"},
     {"id":"soekris-dac","name":"Soekris dam 1021","overlay":"hifiberry-dac","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"speaker-phat","name":"Speaker pHAT","overlay":"hifiberry-dac","alsanum":"2","alsacard":"sndrpihifiberry","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"st400-dac-amp","name":"ST400 Dac (PCM5122) - Amp","overlay":"iqaudio-dacplus","alsanum":"2","alsacard":"IQaudIODAC","mixer":"Digital","modules":"","script":"","needsreboot":"yes"},


### PR DESCRIPTION
This DAC is basically IQaudio DAC+ but it has a different EEPROM content.

https://www.raspberrypi.com/products/dac-plus/