### PR TITLE
Remove redundant search

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -309,7 +309,6 @@ CoreCommandRouter.prototype.volumioImportServicePlaylists = function () {
 // Volumio Search
 CoreCommandRouter.prototype.volumioSearch = function (data) {
   this.pushConsoleMessage('CoreCommandRouter::Search ' + data);
-  var asd = this.musicLibrary.search(data);
 
   return this.musicLibrary.search(data);
 };


### PR DESCRIPTION
This temporary variable is populated but the debug print that used it was removed in July 2017; just perform the search once.

(See my post [here](https://community.volumio.com/t/redundant-call-doubles-search-time/70093) with more details.)