### PR TITLE
Update dacs.json to add support for AudioInjector Stereo i2s DAC hat

### DIFF
--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -8,7 +8,7 @@
     {"id":"allo-boss2-dac","name":"Allo BOSS2","overlay":"allo-boss2-dac-audio","alsanum":"2","alsacard":"Boss2","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
     {"id":"allo-digione","name":"Allo DigiOne","overlay":"allo-digione","alsanum":"2","alsacard":"sndallodigione","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"allo-katana-dac","name":"Allo Katana","overlay":"allo-katana-dac-audio","alsanum":"2","alsacard":"Katana","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
-    {"id":"audio-injector-stereo","name":"AudioInjector Stereo","overlay":"audioinjector-wm8731-audio","alsanum":"2","alsacard":"audioinjectorpi","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
+    {"id":"audio-injector-stereo","name":"AudioInjector Stereo","overlay":"audioinjector-wm8731-audio","alsanum":"2","alsacard":"audioinjectorpi","mixer":"Master","modules":"","script":"aistereo-unmute.sh","needsreboot":"yes"},
     {"id":"audio-injector-bare","name":"AudioInjector bare I2S","overlay":"audioinjector-bare-i2s","alsanum":"2","alsacard":"audioinjectorba","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"audio-injector-isolated","name":"AudioInjector Isolated","overlay":"audioinjector-isolated-soundcard","alsanum":"2","alsacard":"audioinjectoris","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
     {"id":"audio-injector-pro","name":"AudioInjector Pro","overlay":"audioinjector-isolated-soundcard","alsanum":"2","alsacard":"audioinjectoris","mixer":"Master","modules":"","script":"","needsreboot":"yes"},

--- a/app/plugins/system_controller/i2s_dacs/dacs.json
+++ b/app/plugins/system_controller/i2s_dacs/dacs.json
@@ -8,6 +8,7 @@
     {"id":"allo-boss2-dac","name":"Allo BOSS2","overlay":"allo-boss2-dac-audio","alsanum":"2","alsacard":"Boss2","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
     {"id":"allo-digione","name":"Allo DigiOne","overlay":"allo-digione","alsanum":"2","alsacard":"sndallodigione","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"allo-katana-dac","name":"Allo Katana","overlay":"allo-katana-dac-audio","alsanum":"2","alsacard":"Katana","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
+    {"id":"audio-injector-stereo","name":"AudioInjector Stereo","overlay":"audioinjector-wm8731-audio","alsanum":"2","alsacard":"audioinjectorpi","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
     {"id":"audio-injector-bare","name":"AudioInjector bare I2S","overlay":"audioinjector-bare-i2s","alsanum":"2","alsacard":"audioinjectorba","mixer":"","modules":"","script":"","needsreboot":"yes"},
     {"id":"audio-injector-isolated","name":"AudioInjector Isolated","overlay":"audioinjector-isolated-soundcard","alsanum":"2","alsacard":"audioinjectoris","mixer":"Master","modules":"","script":"","needsreboot":"yes"},
     {"id":"audio-injector-pro","name":"AudioInjector Pro","overlay":"audioinjector-isolated-soundcard","alsanum":"2","alsacard":"audioinjectoris","mixer":"Master","modules":"","script":"","needsreboot":"yes"},

--- a/app/plugins/system_controller/i2s_dacs/scripts/aistereo-unmute.sh
+++ b/app/plugins/system_controller/i2s_dacs/scripts/aistereo-unmute.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Unmute Master Playback ZC; card 2 on RPi
+# Unmute Master Playback ZC for Audio Injector Stereo; card 2 on RPi
 amixer -c 2 sset 'Master Playback ZC' unmute
 
-# Unmute Output Mixer HiFi; card 2 on RPi
+# Unmute Output Mixer HiFi Audio Injector Stereo; card 2 on RPi
 amixer -c 2 sset 'Output Mixer HiFi' unmute

--- a/app/plugins/system_controller/i2s_dacs/scripts/aistereo-unmute.sh
+++ b/app/plugins/system_controller/i2s_dacs/scripts/aistereo-unmute.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Unmute Master Playback ZC; card 2 on RPi
+amixer -c 2 sset 'Master Playback ZC' unmute
+
+# Unmute Output Mixer HiFi; card 2 on RPi
+amixer -c 2 sset 'Output Mixer HiFi' unmute


### PR DESCRIPTION
Added support for AudioInjector Stereo card (https://www.audioinjector.net/rpi-hat), of which there is demonstrated demand (e.g., https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=http://forum.audioinjector.net/viewtopic.php%40t%3D3063.html&ved=2ahUKEwjV2-7Y2uGKAxVIweYEHcM3LqoQFnoECBQQAQ&usg=AOvVaw01BVyH3GoGSBTprnx3DjOG and https://lists.audioinjector.net/pipermail/people/2022-January/000400.html).

All the prior fixes don't seem to work -- Volumio automatically rewrites the /etc/asound.conf file to whatever is selected in the GUI, breaking whatever steps are outlined in the forum. 

Therefore, I tried just editing the dacs file as per https://developers.volumio.com/I2S%20DACs

This works on my local instance, per observation. Please let me know if there are any bugs or unmet requirements, and thanks for putting together such a great product!