### PR TITLE
Do not perform forced scanning if device is busy

### DIFF
--- a/app/plugins/system_controller/network/index.js
+++ b/app/plugins/system_controller/network/index.js
@@ -241,7 +241,9 @@ ControllerNetwork.prototype.getWirelessNetworks = function (defer) {
     iwlist.scan('wlan0', function (err, networks) {
       var self = this;
 
-      if (err) {
+      if (err && err.toString().indexOf("Device or resource busy") > -1 ) {
+        defer.resolve(wirelessNetworksScanCache);
+      } else if (err) {
         exself.logger.error('An error occurred while scanning: ' + err);
         exself.logger.info('Cannot use regular scanning, forcing with ap-force');
         var networksarray = [];


### PR DESCRIPTION
On some devices, I am seeing this behavior that websocket service gets stuck when ap-force is used for scanning. When I checked further, I noticed that there were already another call for getWirelessNetworks that was running which caused `iwlist wlan0 scan` in the websocket service call to fail. The code then executed ap-force command that got hanged resulting into websocket service to hang as well.

Hence adding a check to make sure that device is not missing and resulting cached result if device is busy.