### PR TITLE
SW volume control improvement in case of DAC off-on or unplug-plug wout HW mixer

### DIFF
--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -273,23 +273,21 @@ CoreVolumeController.prototype.updateVolumeSettings = function (data) {
 
   self.logger.info('Updating Volume Controller Parameters: Device: ' + data.device + ' Name: ' + data.name + ' Mixer: ' + data.mixer + ' Max Vol: ' + data.maxvolume + ' Vol Curve; ' + data.volumecurve + ' Vol Steps: ' + data.volumesteps);
 
-  if (data.mixertype !== undefined && mixertype !== 'None' && mixer !== undefined && mixer.length && (data.mixertype === 'None' || data.mixertype === 'Software')) {
-    var startupVolume = this.commandRouter.executeOnPlugin('audio_interface', 'alsa_controller', 'getConfigParam', 'volumestart');
-    if (startupVolume !== 'disabled') {
-        self.setVolume(parseInt(startupVolume), function (err) {
-            if (err) {
-                self.logger.error('Cannot set ALSA Volume: ' + err);
-            }
-        });
-    } else {
-        self.setVolume(30, function (err) {
+  if (data.mixertype !== undefined && mixertype !== 'None' && mixer !== undefined && mixer.length) {
+    if (data.mixertype === 'Software') {
+        setTimeout(() => {
+          self.setStartupVolume();
+  //        self.logger.info('new mixertye handling - setstartupvolume');
+        }, 5000);
+    } else if (data.mixertype === 'None') {
+        self.setVolume(100, function (err) {
             if (err) {
                 self.logger.error('Cannot set ALSA Volume: ' + err);
             }
         });
     }
   }
-
+ 
   if (mixertype && mixertype === 'None' && data.mixertype !== undefined && (data.mixertype === 'Software' || data.mixertype === 'Hardware')) {
     setTimeout(() => {
       self.setStartupVolume();


### PR DESCRIPTION
Dear Developers,

Please review my pull request. I have made the following changes to the volumecontrol.js file:

Issue: Addressed an issue where volume control was not functioning correctly when a DAC was turned off and on, or unplugged and plugged back in, without a hardware mixer. (default volume level = 100%)
Solution: Implemented logic to ensure proper volume control functionality in these scenarios.
Testing: Thoroughly tested the changes by simulating DAC off/on and unplug/plug events, confirming that volume control now works as expected.

https://community.volumio.com/t/sw-mixer-volume-level-after-external-dac-off-on/71222