### PR TITLE
Workaround libxmljs breaking changes in webradio plugin

### DIFF
--- a/app/plugins/music_service/webradio/index.js
+++ b/app/plugins/music_service/webradio/index.js
@@ -236,6 +236,19 @@ ControllerWebradio.prototype.listRoot = function () {
   return defer.promise;
 };
 
+function xmlGetAttribute(node, attribute) {
+  if (!node)
+    return null;
+
+  if (typeof node.getAttribute === 'function') {
+    return node.getAttribute(attribute);
+  } else if (typeof node.attr === 'function') {
+    return node.attr(attribute);
+  } else {
+    throw new Error('xmlGetAttribute: node does not have attr or getAttribute method');
+  }
+}
+
 ControllerWebradio.prototype.listRadioGenres = function () {
   var self = this;
 
@@ -283,7 +296,7 @@ ControllerWebradio.prototype.listRadioGenres = function () {
         if (children.length == 0) { self.logger.info('No genres returned by Shoutcast'); }
 
         for (var i in children) {
-          var name = children[i].attr('name').value();
+          var name = xmlGetAttribute(children[i], 'name').value();
           var category = {
             type: 'radio-category',
             title: name,
@@ -350,12 +363,12 @@ ControllerWebradio.prototype.listRadioForGenres = function (curUri) {
 
         for (var i in children) {
           if (children[i].name() === 'tunein') {
-            base = (children[i].attr('base').value()).replace('.pls', '.m3u');
+            base = xmlGetAttribute(children[i], 'base').value().replace('.pls', '.m3u');
           } else if (children[i].name() === 'station') {
-            var name = children[i].attr('name').value();
-            var id = children[i].attr('id').value();
-            var bitrate = children[i].attr('br').value();
-            var streamcodec = children[i].attr('mt').value();
+            var name = xmlGetAttribute(children[i], 'name').value();
+            var id = xmlGetAttribute(children[i], 'id').value();
+            var bitrate = xmlGetAttribute(children[i], 'br').value();
+            var streamcodec = xmlGetAttribute(children[i], 'mt').value();
 
             var category = {
               service: 'webradio',
@@ -425,12 +438,12 @@ ControllerWebradio.prototype.listTop500Radios = function (curUri) {
 
         for (var i in children) {
           if (children[i].name() === 'tunein') {
-            base = (children[i].attr('base').value()).replace('.pls', '.m3u');
+            base = xmlGetAttribute(children[i], 'base').value().replace('.pls', '.m3u');
           } else if (children[i].name() === 'station') {
-            var name = children[i].attr('name').value();
-            var id = children[i].attr('id').value();
-            var bitrate = children[i].attr('br').value();
-            var streamcodec = children[i].attr('mt').value();
+            var name = xmlGetAttribute(children[i], 'name').value();
+            var id = xmlGetAttribute(children[i], 'id').value();
+            var bitrate = xmlGetAttribute(children[i], 'br').value();
+            var streamcodec = xmlGetAttribute(children[i], 'mt').value();
 
             var category = {
               service: 'webradio',
@@ -441,7 +454,7 @@ ControllerWebradio.prototype.listTop500Radios = function (curUri) {
               uri: 'http://yp.shoutcast.com' + base + '?id=' + id
             };
             try {
-              var albumart = children[i].attr('logo').value();
+              var albumart = xmlGetAttribute(children[i], 'logo').value();
               if (albumart != undefined && albumart.length > 0) {
                 category.albumart = albumart;
               } else {
@@ -953,12 +966,12 @@ ControllerWebradio.prototype.searchWithShoutcast = function (search) {
 
         for (var i in children) {
           if (children[i].name() === 'tunein') {
-            base = (children[i].attr('base').value()).replace('.pls', '.m3u');
+            base = xmlGetAttribute(children[i], 'base').value().replace('.pls', '.m3u');
           } else if (children[i].name() === 'station') {
-            var name = children[i].attr('name').value();
-            var id = children[i].attr('id').value();
-            var bitrate = children[i].attr('br').value();
-            var streamcodec = children[i].attr('mt').value();
+            var name = xmlGetAttribute(children[i], 'name').value();
+            var id = xmlGetAttribute(children[i], 'id').value();
+            var bitrate = xmlGetAttribute(children[i], 'br').value();
+            var streamcodec = xmlGetAttribute(children[i], 'mt').value();
 
 
             var category = {
@@ -970,8 +983,8 @@ ControllerWebradio.prototype.searchWithShoutcast = function (search) {
               uri: 'http://yp.shoutcast.com' + base + '?id=' + id
             };
 
-            if (children[i].attr('logo') && children[i].attr('logo').value()) {
-              category.albumart = children[i].attr('logo').value();
+            if (xmlGetAttribute(children[i], 'logo') && xmlGetAttribute(children[i], 'logo').value()) {
+              category.albumart = xmlGetAttribute(children[i], 'logo').value();
             } else {
               category.icon = 'fa fa-microphone';
             }


### PR DESCRIPTION
Depending on whether Debian bookworm or Debian buster is used, the version of the `libxmljs` library will be 1.0.11 or  0.19.7, respectively. Handle the breaking changes with a wrapper.

Closes https://github.com/volumio/volumio3-backend/issues/219