### PR TITLE
Fix fatal error trying to save NaN as number

### DIFF
--- a/app/plugins/system_controller/volumiodiscovery/index.js
+++ b/app/plugins/system_controller/volumiodiscovery/index.js
@@ -317,7 +317,7 @@ ControllerVolumioDiscovery.prototype.connectToRemoteVolumio = function (uuid, ip
 ControllerVolumioDiscovery.prototype.updateMultiroomDevice = function (uuid, data) {
   var self = this;
   foundVolumioInstances.set(uuid + '.status', data.status);
-  if (data.volume === undefined) {
+  if (!data.volume) {
     data.volume = 0;
   }
   foundVolumioInstances.set(uuid + '.volume', data.volume);


### PR DESCRIPTION
This fixes a crash I've observed:
```
|||||||||||||||||||||||| WARNING: FATAL ERROR |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
Error: The value NaN is not a number
    at Config.forceToType (/volumio/node_modules/v-conf/index.js:322:20)
    at Config.set (/volumio/node_modules/v-conf/index.js:153:25)
    at ControllerVolumioDiscovery.updateMultiroomDevice (/volumio/app/plugins/system_controller/volumiodiscovery/index.js:323:25)
    at ControllerVolumioDiscovery.connectToRemoteVolumio (/volumio/app/plugins/system_controller/volumiodiscovery/index.js:273:10)
    at Browser. (/volumio/app/plugins/system_controller/volumiodiscovery/index.js:192:12)
    at Browser.emit (events.js:400:28)
    at on_resolver_done (/volumio/node_modules/mdns/lib/browser.js:31:14)
    at next (/volumio/node_modules/mdns/lib/browser.js:106:7)
    at Array.makeAddressesUnique (/volumio/node_modules/mdns/lib/resolver_sequence_tasks.js:177:5)
    at next (/volumio/node_modules/mdns/lib/browser.js:109:21)
    at /volumio/node_modules/mdns/lib/resolver_sequence_tasks.js:160:11
    at getaddrinfo_complete (/volumio/node_modules/mdns/lib/resolver_sequence_tasks.js:108:7)
    at GetAddrInfoReqWrap.oncomplete (/volumio/node_modules/mdns/lib/resolver_sequence_tasks.js:120:9)
|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
```