### PR TITLE
Fix Favourites

### DIFF
--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -2078,7 +2078,7 @@ InterfaceWebUI.prototype.pushQueue = function (queue, connWebSocket) {
     return libQ.fcall(connWebSocket.emit.bind(connWebSocket), 'pushQueue', queue);
     // Else push to all connected clients
   } else {
-    return libQ.fcall(self.libSocketIO.sockets.emit('pushQueue', queue));
+    return libQ.fcall(self.libSocketIO.sockets.emit.bind(self.libSocketIO.sockets), 'pushQueue', queue);
   }
 };
 
@@ -2134,7 +2134,7 @@ InterfaceWebUI.prototype.pushState = function (state, connWebSocket) {
   } else {
     // Push the updated state to all clients
     self.pushMultiroom(self.libSocketIO);
-    return libQ.fcall(self.libSocketIO.sockets.emit('pushState', state));
+    return libQ.fcall(self.libSocketIO.sockets.emit.bind(self.libSocketIO.sockets), 'pushState', state);
   }
 };
 


### PR DESCRIPTION
In my setup favourites icon does not work.

After some debugging I see that `CoreStateMachine.checkFavourites` never called because `CoreCommandRouter.volumioPushState` resolves with error "callback.apply is not a function".

Next, I see that error comes from `InterfaceWebUI.pushState`, where `libQ.fcall` called with function result instead of a function itself.

See:
https://github.com/volumio/volumio3-backend/blob/master/app/plugins/user_interface/websocket/index.js#L2137

Missed `bind` call or wrapped function in that line:
`return libQ.fcall(self.libSocketIO.sockets.emit('pushState', state));`

Also, same problem exists in `InterfaceWebUI.pushQueue`.