### PR TITLE
Include Pi 500+ NVMe boot

### DIFF
--- a/app/plugins/system_controller/system/usbbootcapable.json
+++ b/app/plugins/system_controller/system/usbbootcapable.json
@@ -40,6 +40,7 @@
     {"name":"Raspberry PI", "permitted":"bootusb", "revision":"c04180"},
     {"name":"Raspberry PI", "permitted":"bootusb", "revision":"d04180"},
     {"name":"Raspberry PI", "permitted":"bootusb", "revision":"d04190"},
+    {"name":"Raspberry PI", "permitted":"bootusb", "revision":"e04190"},
     {"name":"Raspberry PI", "permitted":"bootusb", "revision":"b041a0"},
     {"name":"Raspberry PI", "permitted":"bootusb", "revision":"c041a0"},
     {"name":"Raspberry PI", "permitted":"bootusb", "revision":"d041a0"}


### PR DESCRIPTION
Eligibility  for Raspberry Pi 500+ to use install to disk.