### PR TITLE
Include Pi CM5 16GB Lite NVME boot ID

### DIFF
--- a/app/plugins/system_controller/system/usbbootcapable.json
+++ b/app/plugins/system_controller/system/usbbootcapable.json
@@ -43,5 +43,6 @@
     {"name":"Raspberry PI", "permitted":"bootusb", "revision":"e04190"},
     {"name":"Raspberry PI", "permitted":"bootusb", "revision":"b041a0"},
     {"name":"Raspberry PI", "permitted":"bootusb", "revision":"c041a0"},
-    {"name":"Raspberry PI", "permitted":"bootusb", "revision":"d041a0"}
+    {"name":"Raspberry PI", "permitted":"bootusb", "revision":"d041a0"},
+    {"name":"Raspberry PI", "permitted":"bootusb", "revision":"e041a0"}
 ]}


### PR DESCRIPTION
Eligibility for Raspberry CM5 16GB Lite to use install to disk.