### PR TITLE
Fix DLNA metadata display during playback and add missing track methods

### DIFF
--- a/app/plugins/music_service/upnp_browser/index.js
+++ b/app/plugins/music_service/upnp_browser/index.js
@@ -434,7 +434,7 @@ ControllerUPNPBrowser.prototype.clearAddPlayTrack = function (track) {
       return self.mpdPlugin.sendMpdCommand('add "' + safeUri + '"', []);
     })
     .then(function () {
-      self.commandRouter.stateMachine.setConsumeUpdateService('mpd', false, false);
+      self.commandRouter.stateMachine.setConsumeUpdateService('mpd', true, false);
       return self.mpdPlugin.sendMpdCommand('play', []);
     });
 };
@@ -463,6 +463,22 @@ ControllerUPNPBrowser.prototype.resume = function () {
 
   // TODO don't send 'toggle' if already playing
   return self.mpdPlugin.sendMpdCommand('play', []);
+};
+
+// Skip to next track - required by statemachine
+ControllerUPNPBrowser.prototype.next = function () {
+  var self = this;
+  self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerUPNPBrowser::next');
+
+  return self.mpdPlugin.sendMpdCommand('next', []);
+};
+
+// Skip to previous track - required by statemachine
+ControllerUPNPBrowser.prototype.previous = function () {
+  var self = this;
+  self.commandRouter.pushConsoleMessage('[' + Date.now() + '] ' + 'ControllerUPNPBrowser::previous');
+
+  return self.mpdPlugin.sendMpdCommand('previous', []);
 };
 
 ControllerUPNPBrowser.prototype.seek = function (position) {


### PR DESCRIPTION
**Problem**

When playing tracks from DLNA/UPnP media servers, Volumio displays the filename (e.g., "01 - Track.mp3") instead of proper metadata (title, artist, album). The browse view shows correct metadata, but playback view shows wrong information.

**Cause**

When adding DLNA tracks to the queue, `setConsumeUpdateService()` is called with `ignoremeta=false`. This causes CoreStateMachine to fetch metadata from MPD, which extracts it from the stream URL path rather than using the metadata already present in the queue item from the DLNA browse response.

**Solution**

Change `setConsumeUpdateService()` call to use `ignoremeta=true`, instructing CoreStateMachine to preserve the queue item metadata instead of overwriting it with MPD-derived values.

Additionally, add missing `next()` and `previous()` methods that delegate to MPD. These were causing statemachine warnings in logs.

**Changes**

- `plugins/music_service/upnp_browser/index.js`
  - Line 437: Change `setConsumeUpdateService('mpd', true, false)` to `setConsumeUpdateService('mpd', true, true)`
  - Add `next()` method delegating to MPD
  - Add `previous()` method delegating to MPD
