### PR TITLE
Allow DHCP only for wlan0 and eth0

### DIFF
--- a/app/plugins/system_controller/network/index.js
+++ b/app/plugins/system_controller/network/index.js
@@ -821,13 +821,21 @@ ControllerNetwork.prototype.rebuildNetworkConfig = function (networkInterfaceToR
         ws.write('iface lo inet loopback\n');
         ws.write('\n');
 
+        staticconf.write('allowinterfaces eth0 wlan0\n');
         staticconf.write('hostname\n');
         staticconf.write('duid\n');
-        staticconf.write('option rapid_commit\n');
+        staticconf.write('vendorclassid\n');
+        staticconf.write('persistent\n');
         staticconf.write('option domain_name_servers, domain_name, domain_search, host_name\n');
         staticconf.write('option classless_static_routes\n');
-        staticconf.write('option ntp_servers\n');
+        staticconf.write('option interface_mtu\n');
+        staticconf.write('option host_name\n');
+        staticconf.write('option rapid_commit\n');
         staticconf.write('require dhcp_server_identifier\n');
+        staticconf.write('slaac private\n');
+        staticconf.write('noipv4ll\n');
+        staticconf.write('option classless_static_routes\n');
+        staticconf.write('option ntp_servers\n');
         staticconf.write('nohook lookup-hostname\n');
         staticconf.write('\n');
 

--- a/app/plugins/system_controller/network/index.js
+++ b/app/plugins/system_controller/network/index.js
@@ -829,13 +829,11 @@ ControllerNetwork.prototype.rebuildNetworkConfig = function (networkInterfaceToR
         staticconf.write('option domain_name_servers, domain_name, domain_search, host_name\n');
         staticconf.write('option classless_static_routes\n');
         staticconf.write('option interface_mtu\n');
-        staticconf.write('option host_name\n');
         staticconf.write('option rapid_commit\n');
+        staticconf.write('option ntp_servers\n');
         staticconf.write('require dhcp_server_identifier\n');
         staticconf.write('slaac private\n');
         staticconf.write('noipv4ll\n');
-        staticconf.write('option classless_static_routes\n');
-        staticconf.write('option ntp_servers\n');
         staticconf.write('nohook lookup-hostname\n');
         staticconf.write('\n');
 


### PR DESCRIPTION
Note:
- The consensus was to add just :

allowinterfaces eth0 wlan0
hostname
duid
vendorclassid
persistent
option domain_name_servers, domain_name, domain_search
option classless_static_routes
option interface_mtu
option host_name
option rapid_commit
require dhcp_server_identifier
slaac private
noipv4ll
nohook lookup-hostname

However, since I found some legacy param (and not knowing if they was still useful or not, I left them) so the actual conf is:

allowinterfaces eth0 wlan0
hostname
duid
vendorclassid
persistent
option domain_name_servers, domain_name, domain_search, host_name
option classless_static_routes
option interface_mtu
option host_name
option rapid_commit
require dhcp_server_identifier
slaac private
noipv4ll
option classless_static_routes
option ntp_servers
nohook lookup-hostname


I look forward to know which one is the best to keep, and in case harmonize the default conf on os builder.

Requiring review before merging