### PR TITLE
fix(discovery): prevent CPU spin from socket.io-client infinite reconnection

### DIFF
--- a/app/plugins/system_controller/volumiodiscovery/index.js
+++ b/app/plugins/system_controller/volumiodiscovery/index.js
@@ -395,6 +395,15 @@ ControllerVolumioDiscovery.prototype.connectToRemoteVolumio = function (uuid, ip
       var toAdvertise = self.getDevices();
       self.commandRouter.pushMultiroomDevices(toAdvertise);
     });
+    // FIX: Cleanup socket when max reconnection attempts exhausted
+    socket.on('reconnect_failed', function () {
+      self.logger.info("Discovery: Reconnection failed after max attempts: " + ip);
+      try {
+        socket.removeAllListeners();
+        socket.close();
+      } catch (e) {}
+      self.remoteConnections.delete(uuid);
+    });
   }
 };
 


### PR DESCRIPTION
## Summary

Fixes 100% CPU consumption in the main backend process when WiFi reconnects
with dual-network mode enabled. The issue is caused by socket.io-client
using infinite reconnection attempts by default.

## Problem

When WiFi connects while Ethernet is active:
1. wireless.js restarts avahi daemon
2. Avahi restart triggers mDNS re-announcements
3. volumioDiscovery receives flood of serviceUp events
4. Each serviceUp spawns socket.io-client connection to remote Volumio devices
5. Connections fail during network transition
6. socket.io-client defaults: reconnectionAttempts = Infinity
7. Multiple sockets enter infinite reconnection loops
8. Result: CPU spins at 94-100% in libuv event loop

## Solution

Three surgical fixes to connectToRemoteVolumio():

1. **Add reconnection limits** - Prevent infinite retry loops
2. **Register socket immediately** - Prevent duplicate socket creation from rapid events
3. **Add reconnect_failed handler** - Clean up sockets when max attempts exhausted
