### PR TITLE
refactor(discovery): implement lifecycle cleanup and fix resource leaks

### DIFF
--- a/app/plugins/system_controller/volumiodiscovery/index.js
+++ b/app/plugins/system_controller/volumiodiscovery/index.js
@@ -772,6 +772,22 @@ ControllerVolumioDiscovery.prototype.handleUngracefulDeviceDisappear = function 
   if (foundVolumioInstances.get(uuid + '.name')) {
     try {
       self.logger.info('Discovery: Device ' + foundVolumioInstances.get(uuid + '.name') + ' disappeared ungracefully from network');
+      
+      // FIX: Also remove from registeredUUIDs to allow re-discovery
+      var uuidindex = registeredUUIDs.indexOf(uuid);
+      if (uuidindex !== -1) {
+        registeredUUIDs.splice(uuidindex, 1);
+      }
+      
+      // Close socket if exists
+      var oldSocket = self.remoteConnections.get(uuid);
+      if (oldSocket) {
+        try {
+          oldSocket.removeAllListeners();
+          oldSocket.close();
+        } catch (e) {}
+      }
+      
       foundVolumioInstances.delete(uuid);
       self.remoteConnections.delete(uuid);
       var toAdvertise = self.getDevices();


### PR DESCRIPTION
## Summary

Implements comprehensive resource cleanup and fixes several bugs in the
volumioDiscovery plugin that cause resource leaks, callback failures, and
device re-discovery issues.

## Prerequisites

This PR depends on fix/discovery-cpu-spin-reconnection being merged first.
The refactor builds on top of the CPU spin fix commits https://github.com/volumio/volumio3-backend/pull/258 

## Problems Addressed

### 1. Incomplete onStop cleanup (resource leak)
Original onStop only stops mDNS advertisement. Browser, sockets, and
registeredUUIDs array remain active, causing:
- Socket connection leaks on plugin restart
- mDNS browser continues running
- Memory growth from accumulated registeredUUIDs

### 2. Undefined toAdvertise in serviceUp callback
Callback loop in serviceUp handler uses toAdvertise variable that is never
defined, causing ReferenceError or passing undefined to registered callbacks.

### 3. initSocket timer queue buildup
initSocket creates 15-second delayed connection with no deduplication.
Rapid calls for same device queue multiple timers that all fire sequentially.

### 4. registeredUUIDs not cleaned in handleUngracefulDeviceDisappear
Devices that disappear ungracefully cannot be re-discovered until system
restart because UUID remains in registeredUUIDs array.