### PR TITLE
Do not restart Avahi browsing on failure

### DIFF
--- a/app/plugins/system_controller/volumiodiscovery/index.js
+++ b/app/plugins/system_controller/volumiodiscovery/index.js
@@ -222,7 +222,10 @@ ControllerVolumioDiscovery.prototype.startMDNSBrowse = function () {
 
     self.browser.on('error', function (error) {
       self.context.coreCommand.pushConsoleMessage('Discovery: Browse raised the following error ' + error);
-      self.restartBrowse();
+      // FIXME: This breaks the Bonjour Compliance Test
+      // Under the BCT test conditions, this is spamming DBus connections and reaching the limit for the user,
+      // causing services that rely on DBus to restart. If Avahi restarts during the BCT "chattiness test" we fail.
+      // self.restartBrowse();
     });
     self.browser.on('serviceUp', function (service) {
       if (registeredUUIDs.indexOf(service.txtRecord.UUID) > -1) {


### PR DESCRIPTION
I have observed that under the Bonjour Conformance Test conditions, this causes the service to spam a lot of DBus connections. In turn we reach the limit of DBus connections for the user, causing other services that rely on DBus to restart. 

If Avahi restarts during the BCT "chattiness test" we fail.

These changes are temporary merged on [feat/acert](https://github.com/volumio/volumio3-backend/tree/feat/acert).