### PR TITLE
Disallow systemd dhcpcd daemon from configuring eth0

### DIFF
--- a/app/plugins/system_controller/network/index.js
+++ b/app/plugins/system_controller/network/index.js
@@ -821,7 +821,7 @@ ControllerNetwork.prototype.rebuildNetworkConfig = function (networkInterfaceToR
         ws.write('iface lo inet loopback\n');
         ws.write('\n');
 
-        staticconf.write('allowinterfaces eth0 wlan0\n');
+        staticconf.write('allowinterfaces wlan0\n');
         staticconf.write('hostname\n');
         staticconf.write('duid\n');
         staticconf.write('vendorclassid\n');


### PR DESCRIPTION
Volumio is currently relying on two dhcpcd instances. However, if both are running on both interfaces things break.

Use the systemd dhcpcd for wlan0 only. The dhcpcd instance for eth0 is spawned by ifup according to `/etc/network/interfaces`.

Requires https://github.com/volumio/volumio-os/pull/388.

These changes are temporarily merged on [feat/acert](https://github.com/volumio/volumio3-backend/tree/feat/acert).