### PR TITLE
Write Avahi daemon configuration with correct host name

### DIFF
--- a/app/plugins/system_controller/networkfs/smb.conf.tmpl
+++ b/app/plugins/system_controller/networkfs/smb.conf.tmpl
@@ -1,5 +1,6 @@
 [global]
 netbios name = {NAME}
+mdns name = mdns
 server string = Audiophile Music Player
 workgroup = WORKGROUP
 security = user

--- a/app/plugins/system_controller/volumiodiscovery/avahi-daemon.conf.tmpl
+++ b/app/plugins/system_controller/volumiodiscovery/avahi-daemon.conf.tmpl
@@ -1,0 +1,69 @@
+# This file is part of avahi.
+#
+# avahi is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# avahi is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with avahi; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# USA.
+
+# See avahi-daemon.conf(5) for more information on this configuration
+# file!
+
+[server]
+host-name={NAME}
+#domain-name=local
+#browse-domains=0pointer.de, zeroconf.org
+use-ipv4=yes
+use-ipv6=yes
+#allow-interfaces=eth0
+#deny-interfaces=eth1
+#check-response-ttl=no
+#use-iff-running=no
+#enable-dbus=yes
+#disallow-other-stacks=no
+#allow-point-to-point=no
+#cache-entries-max=4096
+#clients-max=4096
+#objects-per-client-max=1024
+#entries-per-entry-group-max=32
+ratelimit-interval-usec=1000000
+ratelimit-burst=1000
+
+[wide-area]
+enable-wide-area=yes
+
+[publish]
+#disable-publishing=no
+#disable-user-service-publishing=no
+#add-service-cookie=no
+#publish-addresses=yes
+publish-hinfo=no
+publish-workstation=no
+#publish-domain=yes
+#publish-dns-servers=192.168.50.1, 192.168.50.2
+#publish-resolv-conf-dns-servers=yes
+#publish-aaaa-on-ipv4=yes
+#publish-a-on-ipv6=no
+
+[reflector]
+#enable-reflector=no
+#reflect-ipv=no
+#reflect-filters=_airplay._tcp.local,_raop._tcp.local
+
+[rlimits]
+#rlimit-as=
+#rlimit-core=0
+#rlimit-data=8388608
+#rlimit-fsize=0
+#rlimit-nofile=768
+#rlimit-stack=8388608
+#rlimit-nproc=3

--- a/app/plugins/system_controller/volumiodiscovery/index.js
+++ b/app/plugins/system_controller/volumiodiscovery/index.js
@@ -31,8 +31,53 @@ function ControllerVolumioDiscovery (context) {
   self.context = context;
   self.logger = self.context.logger;
   self.commandRouter = self.context.coreCommand;
+  self.commandRouter.sharedVars.registerCallback('system.name', self.playerNameCallback.bind(self));
 
   self.callbacks = [];
+}
+
+ControllerVolumioDiscovery.prototype.writeAvahiDaemonConf = function () {
+  var self = this;
+
+  var systemController = self.commandRouter.pluginManager.getPlugin('system_controller', 'system');
+  var name = systemController.getConf('playerName');
+  var avahiDaemonConfFile = '/etc/avahi/avahi-daemon.conf';
+
+  exec('/usr/bin/sudo /bin/chmod 777 ' + avahiDaemonConfFile, {uid: 1000, gid: 1000},
+    function (error, stdout, stderr) {
+      if (error != null) {
+        self.logger.info('Error setting avahi-daemon.conf file perms: ' + error);
+      } else {
+        self.logger.info('avahi-daemon.conf Permissions set');
+        fs.readFile(__dirname + '/avahi-daemon.conf.tmpl', 'utf8', function (err, data) {
+          if (err) {
+            return self.logger.log('Error reading Avahi daemon configuration template file: ' + err);
+          }
+          var conf = data.replace(/{NAME}/g, name);
+
+          fs.writeFile(avahiDaemonConfFile, conf, 'utf8', function (err) {
+            if (err) {
+              self.logger.log('Error writing Avahi daemon configuration file: ' + err);
+            } else {
+              exec('/usr/bin/sudo /bin/systemctl reload avahi-daemon.service', {uid: 1000, gid: 1000}, function (error, stdout, stderr) {
+                if (error !== null) {
+                  self.logger.error('Cannot reload Avahi daemon');
+                } else {
+                  self.logger.info('Avahi daemon reloaded');
+                }
+              });
+            }
+          });
+        });
+      }
+    });
+}
+
+ControllerVolumioDiscovery.prototype.playerNameCallback = function () {
+  var self = this;
+
+  self.logger.info('System name has changed, updating Avahi daemon configuration');
+  setTimeout(() => self.writeAvahiDaemonConf(), 3000);
 }
 
 ControllerVolumioDiscovery.prototype.getConfigurationFiles = function () {
@@ -129,6 +174,8 @@ ControllerVolumioDiscovery.prototype.onVolumioStart = function () {
 
   var configFile = self.commandRouter.pluginManager.getConfigurationFile(self.context, 'config.json');
   config.loadFile(configFile);
+
+  self.writeAvahiDaemonConf()
 
   self.startAdvertisement();
   self.startMDNSBrowse();


### PR DESCRIPTION
Before this change Avahi would get the host name from the hostname. This is not enough for BCT since it requires capitalization of the name to be correct. Additionally, tell Samba to stop using the NETBIOS name which is always uppercase.

These changes are temporarily merged on [feat/acert](https://github.com/volumio/volumio3-backend/tree/feat/acert).