### PR TITLE
feat: Introduce ALSA event monitoring and volume synchronization

### DIFF
--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -29,6 +29,8 @@ var pendingAlsaRead = false;
 var needsAnotherAlsaRead = false;
 var alsaMonitorProcess = null;
 var shouldMonitorAlsa = false;
+var alsaRestartDelay = 5000;
+var alsaStartTime = 0;
 
 module.exports = CoreVolumeController;
 function CoreVolumeController (commandRouter) {
@@ -151,6 +153,7 @@ function CoreVolumeController (commandRouter) {
     if (alsaMonitorProcess) return;
     if (!shouldMonitorAlsa) return;
 
+    alsaStartTime = Date.now();
     var lineBuffer = '';
 
     self.logger.info('VolumeController:: Starting alsactl monitor');
@@ -181,7 +184,13 @@ function CoreVolumeController (commandRouter) {
       self.logger.info('VolumeController:: alsactl monitor closed, code: ' + code);
       alsaMonitorProcess = null;
       if (code !== 0 && code !== null && shouldMonitorAlsa) {
-        setTimeout(monitorAlsaEvents, 5000);
+        if (Date.now() - alsaStartTime > 10000) {
+          alsaRestartDelay = 5000;
+        } else {
+          alsaRestartDelay = Math.min(alsaRestartDelay * 2, 60000);
+        }
+        self.logger.info('VolumeController:: Restarting alsactl monitor in ' + (alsaRestartDelay / 1000) + 's');
+        setTimeout(monitorAlsaEvents, alsaRestartDelay);
       }
     });
 
@@ -360,6 +369,7 @@ function CoreVolumeController (commandRouter) {
     shouldMonitorAlsa = (mixertype === 'Hardware' && !volumeOverride && !volumescript.enabled);
 
     if (shouldMonitorAlsa) {
+      alsaRestartDelay = 5000;
       if (!alsaMonitorProcess)
         monitorAlsaEvents();
       else {

--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -23,6 +23,9 @@ var volumescript = { enabled: false, setvolumescript: '', getvolumescript: '' };
 var volumeOverride = false;
 var overridePluginType;
 var overridePluginName;
+var pendingAmixerWrites = 0;
+var needsAlsaSync = false;
+var alsaMonitorProcess = null;
 
 module.exports = CoreVolumeController;
 function CoreVolumeController (commandRouter) {
@@ -99,6 +102,80 @@ function CoreVolumeController (commandRouter) {
 
     p.on('close', function () {
       cb(err, ret.trim());
+    });
+  };
+
+  var amixerWrite = function (args, cb) {
+    pendingAmixerWrites++;
+    amixer(args, function (err) {
+      pendingAmixerWrites--;
+      if (pendingAmixerWrites === 0 && needsAlsaSync) {
+        needsAlsaSync = false;
+        checkAndReportAlsaVolume();
+      }
+      if (cb) cb(err);
+    });
+  };
+
+  var checkAndReportAlsaVolume = function () {
+    getInfo(function (err, result) {
+      if (err) {
+        self.logger.error('VolumeController:: checkAndReportAlsaVolume error: ' + err);
+        return;
+      }
+      if (result.volume !== currentvolume || result.muted !== currentmute) {
+        self.logger.info('VolumeController:: External volume change detected: vol=' + result.volume + ' mute=' + result.muted);
+        currentvolume = result.volume;
+        currentmute = result.muted;
+        Volume.vol = result.volume;
+        Volume.mute = result.muted;
+        Volume.disableVolumeControl = false;
+        self.commandRouter.volumioupdatevolume(Volume);
+      }
+    });
+  };
+
+  var monitorAlsaEvents = function () {
+    if (alsaMonitorProcess) return;
+
+    var lineBuffer = '';
+    alsaMonitorProcess = spawn('/usr/sbin/alsactl', ['monitor'], { uid: 1000, gid: 1000 });
+
+    alsaMonitorProcess.stdout.on('data', function (data) {
+      lineBuffer += data.toString();
+      var lines = lineBuffer.split('\n');
+      lineBuffer = lines.pop();
+
+      for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+        if (line.indexOf('hw:' + device) >= 0 &&
+            mixertype === 'Hardware' &&
+            !volumeOverride &&
+            !volumescript.enabled) {
+          if (pendingAmixerWrites > 0) {
+            needsAlsaSync = true;
+          } else {
+            checkAndReportAlsaVolume();
+          }
+        }
+      }
+    });
+
+    alsaMonitorProcess.stderr.on('data', function (data) {
+      self.logger.error('VolumeController:: alsactl monitor stderr: ' + data);
+    });
+
+    alsaMonitorProcess.on('close', function (code) {
+      self.logger.info('VolumeController:: alsactl monitor closed, code: ' + code);
+      alsaMonitorProcess = null;
+      if (code !== 0 && code !== null) {
+        setTimeout(monitorAlsaEvents, 5000);
+      }
+    });
+
+    alsaMonitorProcess.on('error', function (err) {
+      self.logger.error('VolumeController:: alsactl monitor error: ' + err);
+      alsaMonitorProcess = null;
     });
   };
 
@@ -220,22 +297,22 @@ function CoreVolumeController (commandRouter) {
       }
     } else {
       if (volumecurve === 'logarithmic') {
-        amixer(['-M', 'set', '-c', device, mixer, 'unmute', val + '%'], function (err) {
+        amixerWrite(['-M', 'set', '-c', device, mixer, 'unmute', val + '%'], function (err) {
           cb(err);
         });
         if (devicename === 'PianoDACPlus' || devicename === 'Allo Piano 2.1' || devicename === 'PianoDACPlus multicodec-0') {
-          amixer(['-M', 'set', '-c', device, 'Subwoofer', 'unmute', val + '%'], function (err) {
+          amixerWrite(['-M', 'set', '-c', device, 'Subwoofer', 'unmute', val + '%'], function (err) {
             if (err) {
               self.logger.error('Cannot set ALSA Volume: ' + err);
             }
           });
         }
       } else {
-        amixer(['set', '-c', device, mixer, 'unmute', val + '%'], function (err) {
+        amixerWrite(['set', '-c', device, mixer, 'unmute', val + '%'], function (err) {
           cb(err);
         });
         if (devicename === 'PianoDACPlus' || devicename === 'Allo Piano 2.1' || devicename === 'PianoDACPlus multicodec-0') {
-          amixer(['set', '-c', device, 'Subwoofer', 'unmute', val + '%'], function (err) {
+          amixerWrite(['set', '-c', device, 'Subwoofer', 'unmute', val + '%'], function (err) {
             if (err) {
               self.logger.error('Cannot set ALSA Volume: ' + err);
             }
@@ -257,15 +334,17 @@ function CoreVolumeController (commandRouter) {
 
   self.setMuted = function (val, cb) {
     if (hasHWMute) {
-      amixer(['set', '-c', device, mixer, (val ? 'mute' : 'unmute')], function (err) {
+      amixerWrite(['set', '-c', device, mixer, (val ? 'mute' : 'unmute')], function (err) {
         cb(err);
       });
     } else {
-      amixer(['set', '-c', device, mixer, (val ? 0 : premutevolume)], function (err) {
+      amixerWrite(['set', '-c', device, mixer, (val ? 0 : premutevolume)], function (err) {
         cb(err);
       });
     }
   };
+
+  monitorAlsaEvents();
 }
 
 CoreVolumeController.prototype.updateVolumeSettings = function (data) {

--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -169,7 +169,8 @@ function CoreVolumeController (commandRouter) {
 
       for (var i = 0; i < lines.length; i++) {
         var line = lines[i];
-        if (line.indexOf('hw:' + device) >= 0 && shouldMonitorAlsa) {
+        var hwRe = new RegExp('\\bhw:' + device + '(?:,\\d+)?\\b');
+        if (hwRe.test(line) && shouldMonitorAlsa) {
           if (pendingAmixerWrites > 0) {
             needsAlsaSync = true;
           } else {

--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -132,6 +132,9 @@ function CoreVolumeController (commandRouter) {
       pendingAlsaRead = false;
       var scheduleAnother = needsAnotherAlsaRead;
       needsAnotherAlsaRead = false;
+      if (pendingAmixerWrites > 0) {
+        return;
+      }
       if (err) {
         self.logger.error('VolumeController:: checkAndReportAlsaVolume error: ' + err);
       } else if (result.volume !== currentvolume || result.muted !== currentmute) {

--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -25,6 +25,8 @@ var overridePluginType;
 var overridePluginName;
 var pendingAmixerWrites = 0;
 var needsAlsaSync = false;
+var pendingAlsaRead = false;
+var needsAnotherAlsaRead = false;
 var alsaMonitorProcess = null;
 var shouldMonitorAlsa = false;
 
@@ -119,12 +121,18 @@ function CoreVolumeController (commandRouter) {
   };
 
   var checkAndReportAlsaVolume = function () {
+    if (pendingAlsaRead) {
+      needsAnotherAlsaRead = true;
+      return;
+    }
+    pendingAlsaRead = true;
     getInfo(function (err, result) {
+      pendingAlsaRead = false;
+      var scheduleAnother = needsAnotherAlsaRead;
+      needsAnotherAlsaRead = false;
       if (err) {
         self.logger.error('VolumeController:: checkAndReportAlsaVolume error: ' + err);
-        return;
-      }
-      if (result.volume !== currentvolume || result.muted !== currentmute) {
+      } else if (result.volume !== currentvolume || result.muted !== currentmute) {
         self.logger.info('VolumeController:: External volume change detected: vol=' + result.volume + ' mute=' + result.muted);
         currentvolume = result.volume;
         currentmute = result.muted;
@@ -132,6 +140,9 @@ function CoreVolumeController (commandRouter) {
         Volume.mute = result.muted;
         Volume.disableVolumeControl = false;
         self.commandRouter.volumioupdatevolume(Volume);
+      }
+      if (scheduleAnother) {
+        checkAndReportAlsaVolume();
       }
     });
   };

--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -84,7 +84,7 @@ function CoreVolumeController (commandRouter) {
   var amixer = function (args, cb) {
     var ret = '';
     var err = null;
-    var p = spawn('amixer', args, { uid: 1000, gid: 1000 });
+    var p = spawn('/usr/bin/amixer', args, { uid: 1000, gid: 1000 });
 
     p.stdout.on('data', function (data) {
       ret += data;

--- a/app/volumecontrol.js
+++ b/app/volumecontrol.js
@@ -26,6 +26,7 @@ var overridePluginName;
 var pendingAmixerWrites = 0;
 var needsAlsaSync = false;
 var alsaMonitorProcess = null;
+var shouldMonitorAlsa = false;
 
 module.exports = CoreVolumeController;
 function CoreVolumeController (commandRouter) {
@@ -137,8 +138,11 @@ function CoreVolumeController (commandRouter) {
 
   var monitorAlsaEvents = function () {
     if (alsaMonitorProcess) return;
+    if (!shouldMonitorAlsa) return;
 
     var lineBuffer = '';
+
+    self.logger.info('VolumeController:: Starting alsactl monitor');
     alsaMonitorProcess = spawn('/usr/sbin/alsactl', ['monitor'], { uid: 1000, gid: 1000 });
 
     alsaMonitorProcess.stdout.on('data', function (data) {
@@ -148,10 +152,7 @@ function CoreVolumeController (commandRouter) {
 
       for (var i = 0; i < lines.length; i++) {
         var line = lines[i];
-        if (line.indexOf('hw:' + device) >= 0 &&
-            mixertype === 'Hardware' &&
-            !volumeOverride &&
-            !volumescript.enabled) {
+        if (line.indexOf('hw:' + device) >= 0 && shouldMonitorAlsa) {
           if (pendingAmixerWrites > 0) {
             needsAlsaSync = true;
           } else {
@@ -168,7 +169,7 @@ function CoreVolumeController (commandRouter) {
     alsaMonitorProcess.on('close', function (code) {
       self.logger.info('VolumeController:: alsactl monitor closed, code: ' + code);
       alsaMonitorProcess = null;
-      if (code !== 0 && code !== null) {
+      if (code !== 0 && code !== null && shouldMonitorAlsa) {
         setTimeout(monitorAlsaEvents, 5000);
       }
     });
@@ -344,7 +345,22 @@ function CoreVolumeController (commandRouter) {
     }
   };
 
-  monitorAlsaEvents();
+  self.syncAlsaMonitor = function () {
+    shouldMonitorAlsa = (mixertype === 'Hardware' && !volumeOverride && !volumescript.enabled);
+
+    if (shouldMonitorAlsa) {
+      if (!alsaMonitorProcess)
+        monitorAlsaEvents();
+      else {
+        alsaMonitorProcess.once('close', monitorAlsaEvents);
+        alsaMonitorProcess.kill();
+      }
+    } else if (alsaMonitorProcess) {
+      alsaMonitorProcess.kill();
+    }
+  };
+
+  self.syncAlsaMonitor();
 }
 
 CoreVolumeController.prototype.updateVolumeSettings = function (data) {
@@ -397,6 +413,8 @@ CoreVolumeController.prototype.updateVolumeSettings = function (data) {
     this.commandRouter.executeOnPlugin(overridePluginType, overridePluginName, 'updateVolumeSettings', data);
   }
 
+  self.syncAlsaMonitor();
+
   return self.retrievevolume();
 };
 
@@ -406,6 +424,7 @@ CoreVolumeController.prototype.updateVolumeScript = function (data) {
   if (data.setvolumescript !== undefined && data.getvolumescript !== undefined) {
     self.logger.info('Updating Volume script: ' + JSON.stringify(data));
     volumescript = data;
+    self.syncAlsaMonitor();
   }
 };
 


### PR DESCRIPTION
I've implemented missing feature of DAC to Volumio volume and mute synchronization. I used standard tool `alsactl` with `monitor` option. It prints report of a change into standard output. Then I filter it for current device only, read this data by using exisint getVolume function, and, if it the value is different than the last known, I apply it in the service. Comparision with last known value has been added to avoid updates after changing from volumio UI. There is also amixer write invocation counter, which has been added to minimize number of reads during writing process (especially in case of frequent changes from GUI).

There is also checking for hardware mixer, no volumescript, no plugin override, so synchronization works only when necessary.

Tested on:
- Raspberry Pi CM5 (Ferrum Broen) with Ferrum Wandla DAC and with Mytek Brooklyn DAC+
- Volumio 4.144
