### PR TITLE
fix(wizard): poll wireless connection status to avoid first-try false failure

### DIFF
--- a/app/plugins/miscellanea/wizard/index.js
+++ b/app/plugins/miscellanea/wizard/index.js
@@ -210,24 +210,46 @@ volumioWizard.prototype.connectWirelessNetwork = function (data) {
 };
 
 volumioWizard.prototype.reportWirelessConnection = function () {
+  // Poll getWirelessInfo until connected or timeout. dhcpcd performs a 5-second
+  // ARP probe before binding the lease on first connect, so a single check at
+  // +5s after wireless.service activation races with DHCP completion. See
+  // platformSpecific.wirelessRestart for the upstream fixed delay.
   var self = this;
-  var defer = libQ.defer();
-  var netInfo = self.commandRouter.executeOnPlugin('system_controller', 'network', 'getWirelessInfo', '');
+  var maxAttempts = 12;
+  var pollIntervalMs = 2000;
+  var attempt = 0;
 
-  netInfo.then(function (data) {
-    if (data != undefined) {
-      if (data.connected && data.ssid != undefined) {
-        var message = self.commandRouter.getI18nString('NETWORK.WIRELESS_NETWORK_CONNECTION_SUCCESSFUL');
-        var message2 = self.commandRouter.getI18nString('NETWORK.WIRELESS_NETWORK_CONNECTION_SUCCESSFUL_PROCEED');
-        var connStatus = {'wait': false, 'result': message + ' ' + data.ssid + ', ' + message2};
-      } else {
-        var message = self.commandRouter.getI18nString('NETWORK.WIRELESS_NETWORK_CONNECTION_ERROR');
-        var message2 = self.commandRouter.getI18nString('NETWORK.WIRELESS_NETWORK_CONNECTION_ERROR_PROCEED');
-        var connStatus = {'wait': false, 'result': message + ' ' + data.ssid + ', ' + message2};
-      }
-      return self.commandRouter.broadcastMessage('pushWizardWirelessConnResults', connStatus);
+  function broadcastResult (data, connected) {
+    var ssid = (data && data.ssid) ? data.ssid : '';
+    var message;
+    var message2;
+    if (connected) {
+      message = self.commandRouter.getI18nString('NETWORK.WIRELESS_NETWORK_CONNECTION_SUCCESSFUL');
+      message2 = self.commandRouter.getI18nString('NETWORK.WIRELESS_NETWORK_CONNECTION_SUCCESSFUL_PROCEED');
+    } else {
+      message = self.commandRouter.getI18nString('NETWORK.WIRELESS_NETWORK_CONNECTION_ERROR');
+      message2 = self.commandRouter.getI18nString('NETWORK.WIRELESS_NETWORK_CONNECTION_ERROR_PROCEED');
     }
-  });
+    var connStatus = {'wait': false, 'result': message + ' ' + ssid + ', ' + message2};
+    self.commandRouter.broadcastMessage('pushWizardWirelessConnResults', connStatus);
+  }
+
+  function checkOnce () {
+    attempt++;
+    var netInfo = self.commandRouter.executeOnPlugin('system_controller', 'network', 'getWirelessInfo', '');
+    netInfo.then(function (data) {
+      var connected = !!(data && data.connected && data.ssid);
+      if (connected) {
+        broadcastResult(data, true);
+      } else if (attempt >= maxAttempts) {
+        broadcastResult(data, false);
+      } else {
+        setTimeout(checkOnce, pollIntervalMs);
+      }
+    });
+  }
+
+  checkOnce();
 };
 
 volumioWizard.prototype.getWizardConfig = function (data) {


### PR DESCRIPTION
## Summary
- WiFi setup wizard reported a false \`WIRELESS_NETWORK_CONNECTION_ERROR\` on the first attempt after a fresh image / reset, even when the connection succeeded a moment later.
- Root cause: \`reportWirelessConnection\` did a single \`getWirelessInfo\` check fired by a hardcoded 5s timer in \`platformSpecific.wirelessRestart\`. dhcpcd's default 5s ARP probe on first connect races that deadline; on retry the cached lease binds in <1s, which is why "second try always works".
- Fix: replace the single-shot check with a 2s/24s poll (12 attempts). Broadcast success the moment IP is bound, fall through to the existing error message only if the full window elapses. Self-contained to the wizard plugin — \`wireless.js\` and \`platformSpecific.wirelessRestart\` are untouched.

## Why scope this narrowly
- \`wireless.js:972\` calls \`notifyWirelessReady\` early on purpose (keeps systemd from killing the service during the 30s polling loop). Leave it.
- The 5s timer in \`platformSpecific.js\` becomes a "minimum delay before first check" rather than a deadline — broader changes there would have wider blast radius.
- A \`noarp\` directive in \`/etc/dhcpcd.conf\` would shave the 5s probe but trades away duplicate-address detection; out of scope for this fix.

## Diagnostic evidence
On a Motivo (CM4, bookworm, 4.149) capture, the connection completed at +17s from "Connect" press:
- \`+8s\` WPA \`COMPLETED\`
- \`+10s\` dhcpcd offer received
- \`+12s\` dhcpcd starts ARP probing 192.168.1.109/24
- \`+17s\` \`leased 192.168.1.109\`

The single-shot \`reportWirelessConnection\` fires at +17s in this capture (knife-edge race). Slower routers / weaker signal cross the 5s budget consistently → users see "fail on first try, retry works".

## Test plan
- [ ] Deploy patched \`wizard/index.js\` to a freshly-flashed device (\`/data/configuration/netconfigured\` absent).
- [ ] Reboot, run the WiFi wizard on first try, verify success message appears and no error toast precedes it.
- [ ] Verify retry path still works (pre-existing \`netconfigured\`, change SSID).
- [ ] Verify failure path: enter a wrong passphrase, confirm \`WIRELESS_NETWORK_CONNECTION_ERROR\` still appears (after the ~24s window).
- [ ] Confirm \`pushWizardWirelessConnResults\` payload shape on the websocket is unchanged for the UI consumers.