### PR TITLE
feat(http): serve /volumio/http/ultraui for ultraui User-Agent

### DIFF
--- a/http/index.js
+++ b/http/index.js
@@ -79,8 +79,15 @@ try {
 } catch(e) {}
 
 app.use(function (req, res, next) {
-  var userAgent = req.get('user-agent');
-  if (process.env.SHOW_NEW_WIZARD === 'true') {
+  var userAgent = req.get('user-agent') || '';
+  if (userAgent.indexOf('ultraui') !== -1) {
+    express.static('/volumio/http/ultraui', { fallthrough: false })(req, res, function (err) {
+      if (err && err.statusCode === 404 && req.method === 'GET' && req.accepts('html')) {
+        return res.sendFile('/volumio/http/ultraui/index.html');
+      }
+      next(err);
+    });
+  } else if (process.env.SHOW_NEW_WIZARD === 'true') {
     express.static(newWizardDir)(req, res, next);
   } else {
     express.static(process.env.VOLUMIO_ACTIVE_UI_PATH)(req, res, next);


### PR DESCRIPTION
Adds a small middleware ahead of the existing concept-ui static resolver: when the request User-Agent contains the literal token "ultraui", static files are served from /volumio/http/ultraui/ with SPA fallback to that directory's index.html on 404 GET html requests.

All other clients (phones, desktop browsers, the existing touchdisplay-plugin kiosk) keep falling through to the wizard or the VOLUMIO_ACTIVE_UI_PATH static root exactly as before — no behavior change for them.

Lets the new on-device kiosk UI (volumio-ultraui, 1480x320 landscape touchscreen) coexist with concept-ui on the same backend without an active-UI swap.