### PR TITLE
fix(plugins): install one plugin at a time (VOL-1510)

### DIFF
--- a/app/i18n/strings_en.json
+++ b/app/i18n/strings_en.json
@@ -369,7 +369,8 @@
         "UNINSTALLING_PLUGIN": "Uninstalling plugin",
         "UNPACKING_PLUGIN": "Unpacking plugin",
         "UPDATING_PLUGIN": "Updating Plugin",
-        "UPDATING_PLUGIN_FILES": "Updating plugin files"
+        "UPDATING_PLUGIN_FILES": "Updating plugin files",
+        "WAITING_FOR_RUNNING_INSTALL": "Another plugin is being installed, this one starts as soon as that finishes"
     },
     "SYSTEM": {
         "ALLOW_UI_STATISTICS": "Allow UI Statistics collection",

--- a/app/pluginmanager.js
+++ b/app/pluginmanager.js
@@ -751,7 +751,47 @@ PluginManager.prototype.checkRequiredConfigurationParameters = function (require
   configJson.save();
 };
 
+/**
+ * Runs an install/update pipeline one at a time.
+ * The pipeline works on fixed shared paths (/tmp/downloaded_plugin.zip,
+ * /data/temp/downloaded_plugin, /tmp/installog), so two of them running
+ * together delete and truncate each other's files: installing several plugins
+ * in a row fails with 'Error unzipping plugin: Command failed:
+ * /usr/bin/miniunzip -o /tmp/downloaded_plugin.zip', because the zip was
+ * already removed by the sibling install or was still being downloaded.
+ * @param task function returning the pipeline promise
+ */
+PluginManager.prototype.queueInstallTask = function (task) {
+  var self = this;
+
+  self.installsPending = (self.installsPending || 0) + 1;
+  if (self.installsPending > 1) {
+    self.logger.info('An install is already running, queueing this one');
+    self.pushMessage('installPluginStatus', {
+      'progress': 5,
+      'message': self.coreCommand.getI18nString('PLUGINS.WAITING_FOR_RUNNING_INSTALL'),
+      'title': self.coreCommand.getI18nString('PLUGINS.INSTALLING_PLUGIN')
+    });
+  }
+
+  // run the task whatever the previous one did, but keep the chain resolved so
+  // a failed install does not block every install queued behind it
+  var run = (self.installChain || libQ.resolve()).then(task, task);
+  var release = function () {
+    self.installsPending--;
+  };
+  self.installChain = run.then(release, release);
+
+  return run;
+};
+
 PluginManager.prototype.installPlugin = function (url) {
+  var self = this;
+
+  return self.queueInstallTask(self.doInstallPlugin.bind(self, url));
+};
+
+PluginManager.prototype.doInstallPlugin = function (url) {
   var self = this;
   var defer = libQ.defer();
   var modaltitle = self.coreCommand.getI18nString('PLUGINS.INSTALLING_PLUGIN');
@@ -915,6 +955,12 @@ PluginManager.prototype.installPlugin = function (url) {
 };
 
 PluginManager.prototype.updatePlugin = function (data) {
+  var self = this;
+
+  return self.queueInstallTask(self.doUpdatePlugin.bind(self, data));
+};
+
+PluginManager.prototype.doUpdatePlugin = function (data) {
   var self = this;
   var defer = libQ.defer();
   var modaltitle = self.coreCommand.getI18nString('PLUGINS.UPDATING_PLUGIN');
@@ -1123,9 +1169,12 @@ PluginManager.prototype.unzipPackage = function () {
 
   }
 
-  exec('/usr/bin/miniunzip -o /tmp/downloaded_plugin.zip -d ' + extractFolder, {maxBuffer: 816000}, function (error) {
+  exec('/usr/bin/miniunzip -o /tmp/downloaded_plugin.zip -d ' + extractFolder, {maxBuffer: 816000}, function (error, stdout) {
     if (error !== null) {
-      defer.reject(new Error('Error unzipping plugin: ' + error));
+      // miniunzip reports its own failures ('Cannot open ...') on stdout and
+      // leaves stderr empty, so without its last line the error says nothing
+      var reason = String(stdout).trim().split('\n').pop();
+      defer.reject(new Error('Error unzipping plugin: ' + error + ' ' + reason));
     } else {
       defer.resolve(extractFolder);
     }

--- a/test/plugin_install_queue.js
+++ b/test/plugin_install_queue.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var assert = require('assert');
+var libQ = require('kew');
+var PluginManager = require('../app/pluginmanager');
+
+// The install pipeline works on fixed shared paths, so two installs running
+// together delete each other's files: queueInstallTask must run one at a time,
+// and one failing install must not block the ones queued behind it.
+describe('plugin install queue', function () {
+  it('runs queued installs one at a time, a failed one does not block the next', function (done) {
+    var manager = Object.create(PluginManager.prototype);
+    manager.logger = {info: function () {}};
+    manager.coreCommand = {getI18nString: function (key) { return key; }};
+
+    var running = 0;
+    var started = [];
+    var queuedMessages = [];
+
+    manager.pushMessage = function (event, data) {
+      queuedMessages.push(event + ' ' + data.progress + ' ' + data.message);
+    };
+
+    function task (i, shouldFail) {
+      return function () {
+        running++;
+        assert.strictEqual(running, 1, 'install ' + i + ' started while another one was running');
+        started.push(i);
+        var defer = libQ.defer();
+        process.nextTick(function () {
+          running--;
+          if (shouldFail) defer.reject(new Error('install ' + i + ' failed'));
+          else defer.resolve(i);
+        });
+        return defer.promise;
+      };
+    }
+
+    var first = manager.queueInstallTask(task(0, true));
+    manager.queueInstallTask(task(1));
+    var last = manager.queueInstallTask(task(2));
+
+    first.then(function () {
+      done(new Error('a failed install must reject the caller'));
+    }, function () {});
+
+    last.then(function () {
+      assert.deepStrictEqual(started, [0, 1, 2]);
+      assert.strictEqual(running, 0);
+      // the two installs that had to wait told the user so, the first did not
+      assert.strictEqual(queuedMessages.length, 2);
+      // the queue is empty again, so the next install must not report a wait
+      manager.queueInstallTask(task(3)).then(function () {
+        assert.strictEqual(queuedMessages.length, 2);
+        done();
+      }, done);
+    }, done);
+  });
+});


### PR DESCRIPTION
## VOL-1510 — bulk plugin install fails with a miniunzip error

Installing several plugins in a row on a Motivo failed with

```
Error: Error unzipping plugin: Error: Command failed:
/usr/bin/miniunzip -o /tmp/downloaded_plugin.zip -d /data/temp/downloaded_plugin
```

The ticket asks which of the three plugins is at fault. None of them: it is the
install pipeline itself, and it fails for *any* set of plugins installed
together.

### Root cause

`installPlugin()` works on fixed, shared paths — `/tmp/downloaded_plugin.zip`,
`/data/temp/downloaded_plugin`, `/tmp/installog` — and nothing serialized it.
Two pipelines running at once destroy each other's files:

* `unzipPackage()` deletes `/tmp/downloaded_plugin.zip` when it finishes — that
  is the zip the sibling install just downloaded, or is still downloading
  (a half-written zip gives the exact same `Cannot open …` from miniunzip)
* `tempCleanup()` removes all of `/data/temp` at the end of a successful install,
  including a sibling's extracted plugin
* both installs extract into the same `/data/temp/downloaded_plugin`, so
  `renameFolder`/`checkPluginDependencies` can read the *other* plugin's
  `package.json` — that is the `Cannot read properties of undefined (reading
  'engines')` variant users also report
* the `install.sh` scripts run concurrently and fight over the dpkg lock

Every entry point can fire installs at once: the store UI (one socket emit per
click, `concept-ui/.../plugin-manager.controller.js`), the zip uploader
(`http/index.js`), `installBackupPlugins()` (`app/index.js` — a loop over every
plugin of a category, i.e. a literal bulk install on backup restore) and
`volumio plugin install`. Fixing it in one caller would leave the others broken,
so the serialization belongs in `PluginManager`.

### The change

* `queueInstallTask()` runs install/update pipelines one after another. The
  chain is kept resolved, so an install that fails does not block the ones
  queued behind it, while its own caller still gets the rejection.
* `installPlugin()` / `updatePlugin()` are thin wrappers over the unchanged
  pipeline bodies (`doInstallPlugin` / `doUpdatePlugin`).
* An install that has to wait pushes `progress: 5` with a new string instead of
  leaving the installer modal empty for minutes.
* The unzip error now carries miniunzip's own last line. miniunzip is the
  `minizip` demo tool: it prints `Cannot open <file> or <file>.zip` on **stdout**
  and leaves stderr empty while exiting non-zero, and `exec()` builds its
  `Command failed:` message from stderr — which is why the reported error had no
  reason attached.

### Verification (device, Volumio 4.195, bookworm, aarch64)

Three synthetic 26 MB plugins served over HTTP, installed with three
back-to-back `installPlugin` socket emits:

| | stock | with this change |
|---|---|---|
| plugins installed | **0 / 3** | **3 / 3** (two consecutive rounds) |
| errors | `Error unzipping plugin: … miniunzip …`, `Cannot read properties of undefined (reading 'engines')` ×2 | none |
| journal | pipelines interleaved | `An install is already running, queueing this one` ×2, then three strictly sequential pipelines |

miniunzip's behaviour was also checked directly on the device: a valid zip
extracts fine, a missing zip and a truncated zip both exit non-zero with empty
stderr and `Cannot open …` on stdout — the reported error signature.

`test/plugin_install_queue.js` asserts installs never overlap, ordering is
preserved, a failed install rejects its caller without blocking the queue, and
the "waiting" notice fires only for installs that actually waited. It passes
against the patched module on the device and fails (`TypeError:
manager.queueInstallTask is not a function`) against the stock one.

### Follow-up found on the way (not in this diff)

`moveToCategory()` calls `exec()` *inside* `.then(...)` instead of passing a
function, so the `mv` starts before `createFolder()` has resolved. Harmless
today because the category folder usually already exists, but it is a real race
and deserves its own one-line fix.
