### PR TITLE
appearance: persist and broadcast the web UI theme (setUiTheme)

### DIFF
--- a/app/plugins/miscellanea/appearance/index.js
+++ b/app/plugins/miscellanea/appearance/index.js
@@ -172,6 +172,18 @@ volumioAppearance.prototype.getUiSettings = function () {
     var UiSettings = {'color': background_color, 'language': language, 'theme': theme};
   }
 
+  // Web UI look, shared by every client of this device (see setUiTheme).
+  // Only present once a client has saved one, so older UIs see the exact
+  // payload they always did.
+  var uiTheme = config.get('ui_theme');
+  if (uiTheme !== undefined) {
+    UiSettings.uiTheme = uiTheme;
+  }
+  var uiAccent = config.get('ui_accent');
+  if (uiAccent !== undefined) {
+    UiSettings.uiAccent = uiAccent;
+  }
+
   defer.resolve(UiSettings);
   return defer.promise;
 };
@@ -314,6 +326,41 @@ volumioAppearance.prototype.setBackgrounds = function (data) {
   }
 
   return ('Done');
+};
+
+/**
+ * Persist the web UI look chosen on one client so every client of this device
+ * paints the same: the on-device display, the browser and the mobile app's
+ * WebView each keep their own localStorage, so without this a theme picked in
+ * the app never reached the device's screen.
+ *
+ * data.theme: 'dark' | 'light' | 'system'; data.accent: 'auto' | 'default' | 'red'.
+ * Either may be omitted; unknown values are ignored. Broadcasts pushUiSettings
+ * (with the new uiTheme / uiAccent keys) to all connected clients.
+ */
+volumioAppearance.prototype.setUiTheme = function (data) {
+  var self = this;
+  var themes = ['dark', 'light', 'system'];
+  var accents = ['auto', 'default', 'red'];
+  var changed = false;
+
+  if (data && themes.indexOf(data.theme) !== -1) {
+    config.set('ui_theme', data.theme);
+    changed = true;
+  }
+  if (data && accents.indexOf(data.accent) !== -1) {
+    config.set('ui_accent', data.accent);
+    changed = true;
+  }
+  if (!changed) {
+    self.logger.warn('setUiTheme: ignoring payload without a valid theme or accent');
+    return libQ.resolve();
+  }
+
+  return self.getUiSettings().then(function (settings) {
+    self.commandRouter.broadcastMessage('pushUiSettings', settings);
+    return settings;
+  });
 };
 
 volumioAppearance.prototype.setLanguage = function (data) {

--- a/app/plugins/user_interface/websocket/index.js
+++ b/app/plugins/user_interface/websocket/index.js
@@ -1579,6 +1579,14 @@ function InterfaceWebUI (context) {
       } else self.logger.error('Cannot set UI Settings');
     });
 
+    connWebSocket.on('setUiTheme', function (data) {
+      // The plugin broadcasts pushUiSettings itself, to every client: the
+      // point of this event is that the other screens follow.
+      var returnedData = self.commandRouter.executeOnPlugin('miscellanea', 'appearance', 'setUiTheme', data);
+
+      if (returnedData == undefined) self.logger.error('Cannot set UI theme');
+    });
+
     connWebSocket.on('deleteBackground', function (data) {
       var selfConnWebSocket = this;
 


### PR DESCRIPTION
## Problem
A theme/accent picked in the Volumio app's WebView (Nova) is not reflected on the connected device's own display or in other browsers. Nova keeps the preference in `localStorage`, per origin, and the backend had no way to hold it.

## Solution
- `appearance.setUiTheme(data)`: validates `theme` ∈ dark/light/system and `accent` ∈ auto/default/red, stores `ui_theme` / `ui_accent`, then broadcasts `pushUiSettings` to all clients (same pattern as `setBackgrounds`).
- `getUiSettings`: adds `uiTheme` / `uiAccent` only when set, so legacy UIs see an unchanged payload.
- websocket: `setUiTheme` event → plugin.

Pairs with VolumioTeam/volumio-nova-theme PR "feat(theme): share the look across every client of a device", which sends the event and adopts the broadcast.

## Testing
- Syntax-checked both files.
- On a device with the Nova PR: `socket.emit('setUiTheme', {theme:'light'})` → every connected client receives `pushUiSettings` with `uiTheme: 'light'`; a payload like `{theme:'sepia'}` logs a warning and changes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)